### PR TITLE
Ajust splitview for iPad

### DIFF
--- a/Gist/Presentation/Sources/Scenes/Discover/DiscoverTableViewController.swift
+++ b/Gist/Presentation/Sources/Scenes/Discover/DiscoverTableViewController.swift
@@ -39,6 +39,7 @@ public final class DiscoverTableViewController: BaseTableViewController {
     }
 
     public override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        showDetailViewController(GistViewController(), sender: self)
+        let navigationController = UINavigationController(rootViewController: GistViewController())
+        showDetailViewController(navigationController, sender: self)
     }
 }

--- a/Gist/Presentation/Sources/Scenes/Gist/GistViewController.swift
+++ b/Gist/Presentation/Sources/Scenes/Gist/GistViewController.swift
@@ -5,6 +5,16 @@ public final class GistViewController: BaseViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
 
+        view.backgroundColor = .random
         title = "Gist"
+    }
+}
+
+extension UIColor {
+    static var random: UIColor {
+        return UIColor(red: .random(in: 0...1),
+                       green: .random(in: 0...1),
+                       blue: .random(in: 0...1),
+                       alpha: 1.0)
     }
 }

--- a/Gist/Presentation/Sources/SplitView/SplitViewController.swift
+++ b/Gist/Presentation/Sources/SplitView/SplitViewController.swift
@@ -8,6 +8,8 @@ public final class SplitViewController: UISplitViewController {
     private func setupMasterAndDetail() {
         let master = UINavigationController(rootViewController: DiscoverTableViewController())
 
+        master.navigationBar.prefersLargeTitles = true
+
         viewControllers = [master]
     }
 }


### PR DESCRIPTION
## Issue Link 🔗
Setup SplitView #32

## Goals ⚽
Supporting multiple orientations and sizes

## Implementation Details 🚧
Create navigation using SplitView that works pretty good on iPads

## Testing Details 🔍
### On iPhone
- On Discovery screen, select any item
- A detail screen should be pushed
- You should be able to pop this view and return to the Discovery properly

### On iPad
- The first state is a split view containing the Discovery list and a blank screen on the right.
- Select an item and you should see the Detail screen switching colors.
